### PR TITLE
ユーザートップページの実装

### DIFF
--- a/layouts/client.vue
+++ b/layouts/client.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app>
+  <v-app style="background-color: #f9fbfe">
     <v-navigation-drawer v-model="drawer" temporary fixed app>
       <v-list>
         <v-list-item
@@ -34,9 +34,7 @@
       <v-toolbar-title v-text="title" />
     </v-app-bar>
     <v-main>
-      <v-container>
-        <nuxt />
-      </v-container>
+      <nuxt />
     </v-main>
   </v-app>
 </template>

--- a/pages/login/index.vue
+++ b/pages/login/index.vue
@@ -75,7 +75,7 @@ export default {
         if (authUser.is_admin) {
           this.$router.push('/admin')
         } else {
-          this.$router.push('/client')
+          this.$router.push('/user')
         }
       } catch (error) {
         this.isShowError = true

--- a/pages/user/index.vue
+++ b/pages/user/index.vue
@@ -1,0 +1,100 @@
+<template>
+  <v-container>
+    <v-card class="my-5">
+      <v-row justify="center" dense>
+        <v-col cols="auto" class="pa-0">
+          <v-list-item class="mx-auto">
+            <v-list-item-icon class="mr-3">
+              <v-icon color="blue darken-4" large>mdi-account-circle</v-icon>
+            </v-list-item-icon>
+            <v-list-item-title>
+              <span class="font-weight-medium text-h6">
+                {{ authUser.name }}
+              </span>
+              さん
+            </v-list-item-title>
+          </v-list-item>
+        </v-col>
+        <v-col cols="auto" class="pa-0" align-self="center">
+          <v-list-item class="mx-auto">
+            <v-list-item-icon class="mr-3">
+              <v-icon color="blue darken-4" large>mdi-check</v-icon>
+            </v-list-item-icon>
+            <v-list-item-title>
+              <span class="caption">完了したレッスン</span>
+              <span class="font-weight-medium text-h6">
+                {{ completeCount }}
+              </span>
+            </v-list-item-title>
+          </v-list-item>
+        </v-col>
+      </v-row>
+    </v-card>
+    <p class="mb-0 font-weight-bold blue-grey--text text--darken-3 mt-5">
+      教材一覧
+    </p>
+    <v-row justify="start">
+      <v-col v-for="category in categories" :key="category" cols="4">
+        <v-card class="mx-auto mt-5" nuxt :href="'material/' + category.id">
+          <v-row align="end" class="fill-height">
+            <v-col cols="auto" class="py-0">
+              <v-avatar color="grey" size="80" rounded>
+                <v-img :src="category.image_src"></v-img>
+              </v-avatar>
+            </v-col>
+            <v-col align-self="center">
+              <v-card-title class="py-0 px-0">{{ category.name }}</v-card-title>
+            </v-col>
+          </v-row>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+import UserService from '@/services/UserService'
+import { mapGetters } from 'vuex'
+import { getError } from '~/utils/helpers'
+export default {
+  layout: 'user',
+  data: () => ({
+    categories: null,
+    statuses: null,
+    completeCount: null,
+  }),
+  computed: {
+    ...mapGetters('auth', ['authUser']),
+  },
+  mounted() {
+    this.$store.dispatch('auth/getAuthUser')
+    this.getCategory()
+    this.getStatus()
+  },
+  methods: {
+    getCategory() {
+      UserService.getCategory()
+        .then((res) => {
+          this.categories = res.data.data
+        })
+        .catch((error) => {
+          getError(error)
+        })
+    },
+    getStatus() {
+      UserService.getStatus()
+        .then((res) => {
+          this.statuses = res.data.data
+          this.completeCount = this.statuses.filter(
+            (item) => item.is_complete === 1
+          ).length
+        })
+        .catch((error) => {
+          getError(error)
+        })
+    },
+  },
+}
+</script>
+
+<style scoped></style>

--- a/pages/user/index.vue
+++ b/pages/user/index.vue
@@ -58,41 +58,29 @@ import { mapGetters } from 'vuex'
 import { getError } from '~/utils/helpers'
 export default {
   layout: 'user',
+  async asyncData({ store }) {
+    await store.dispatch('auth/getAuthUser')
+    const categoryResponse = await UserService.getCategory().catch((err) => {
+      return getError(err)
+    })
+    const statusResponse = await UserService.getStatus().catch((err) => {
+      return getError(err)
+    })
+    return {
+      categories: categoryResponse.data.data,
+      statuses: statusResponse.data.data,
+    }
+  },
   data: () => ({
-    categories: null,
-    statuses: null,
     completeCount: null,
   }),
   computed: {
     ...mapGetters('auth', ['authUser']),
   },
   mounted() {
-    this.$store.dispatch('auth/getAuthUser')
-    this.getCategory()
-    this.getStatus()
-  },
-  methods: {
-    getCategory() {
-      UserService.getCategory()
-        .then((res) => {
-          this.categories = res.data.data
-        })
-        .catch((error) => {
-          getError(error)
-        })
-    },
-    getStatus() {
-      UserService.getStatus()
-        .then((res) => {
-          this.statuses = res.data.data
-          this.completeCount = this.statuses.filter(
-            (item) => item.is_complete === 1
-          ).length
-        })
-        .catch((error) => {
-          getError(error)
-        })
-    },
+    this.completeCount = this.statuses.filter(
+      (item) => item.is_complete === 1
+    ).length
   },
 }
 </script>

--- a/services/API.js
+++ b/services/API.js
@@ -1,0 +1,9 @@
+import axios from 'axios'
+
+export const apiClient = axios.create({
+  baseURL: process.env.API_URL + '/api',
+  withCredentials: true,
+  headers: {
+    Accept: 'application/json',
+  },
+})

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -1,0 +1,10 @@
+import * as API from '@/services/API'
+
+export default {
+  getCategory() {
+    return API.apiClient.get('/category')
+  },
+  getStatus() {
+    return API.apiClient.get('/status')
+  },
+}


### PR DESCRIPTION
## 作業内容
- 共通のAPI処理の実装（``services/API.js``,``services/UserService.js``）
- ユーザーログイン後のページ作成（``pages/user/index.vue``）
- ルーティングやレイアウトの細かな修正を行いましたが，主な変更は上記の2つです

## 期待する動作
``localhost:3000/login``から``user@example.com``,``password``でログイン後，ユーザーの情報と教材の一覧が表示される
![image](https://user-images.githubusercontent.com/47177922/117644954-fd852580-b1c4-11eb-9a53-e60491c89615.png)
