### PR TITLE
クイズページの作成

### DIFF
--- a/pages/user/material/quiz/_id.vue
+++ b/pages/user/material/quiz/_id.vue
@@ -122,8 +122,8 @@ export default {
       this.loaded = true
     },
     pickUpColor(item) {
-      const correctColor = 'pink lighten-5'
-      const incorrectColor = 'blue lighten-5'
+      const correctColor = 'white'
+      const incorrectColor = 'pink lighten-5'
       if (this.isAfterScoring) {
         return item.is_correct ? correctColor : incorrectColor
       }

--- a/pages/user/material/quiz/_id.vue
+++ b/pages/user/material/quiz/_id.vue
@@ -1,0 +1,169 @@
+<template>
+  <v-container>
+    <v-card>
+      <p v-if="isAfterScoring" class="ml-5 pt-3 pb-3">
+        <span class="text-h6 font-weight-regular mr-3">Score</span>
+        <span class="font-weight-bold text-h5">
+          {{ score }}
+        </span>
+        /100％
+      </p>
+    </v-card>
+    <div v-if="loaded" class="mt-3">
+      <v-card
+        v-for="item in quiz"
+        :key="item.id"
+        class="mb-5"
+        :color="pickUpColor(item)"
+      >
+        <v-card-text>
+          <p class="py-3 pl-3 mb-0 black--text">{{ item.content }}</p>
+          <p v-if="isAfterScoring" class="pl-3 black--text">
+            解説: {{ item.explanation }}
+          </p>
+          <div v-for="choice in item.choices" :key="choice.id">
+            <v-row class="ml-3">
+              <v-checkbox
+                v-model="choice.user_answer"
+                :label="choice.content"
+                :disabled="isAfterScoring"
+              ></v-checkbox>
+              <v-icon
+                v-if="isAfterScoring && choice.is_answer"
+                class="ml-5"
+                color="teal accent-4"
+              >
+                mdi-checkbox-marked-circle
+              </v-icon>
+            </v-row>
+          </div>
+        </v-card-text>
+      </v-card>
+    </div>
+    <div class="text-center">
+      <v-btn
+        v-if="isAfterScoring"
+        color="teal accent-4"
+        elevation="2"
+        outlined
+        rounded
+        :loading="sendingScore"
+        @click="$router.go(-2)"
+      >
+        戻る
+      </v-btn>
+      <v-btn
+        v-else
+        color="teal accent-4"
+        elevation="2"
+        outlined
+        rounded
+        @click="scoring()"
+      >
+        採点する
+      </v-btn>
+    </div>
+  </v-container>
+</template>
+
+<script>
+import UserService from '@/services/UserService'
+import { getError } from '~/utils/helpers'
+export default {
+  layout: 'client',
+  async asyncData(context) {
+    const quizResponse = await UserService.getQuiz(context.params.id).catch(
+      (err) => {
+        return getError(err)
+      }
+    )
+    const statusResponse = await UserService.getStatus().catch((err) => {
+      return getError(err)
+    })
+    return {
+      quiz: quizResponse.data.data,
+      statuses: statusResponse.data.data,
+    }
+  },
+  data: () => ({
+    score: null,
+    loaded: true,
+    isAfterScoring: false,
+    sendingScore: false,
+  }),
+  created() {
+    this.quiz.forEach((item) => {
+      item.is_correct = false
+      item.choices.forEach((choice) => {
+        choice.user_answer = false
+      })
+    })
+  },
+  methods: {
+    scoring() {
+      let isCorrect = true
+      this.loaded = false
+      let correctCount = 0
+      this.quiz.forEach((item) => {
+        isCorrect = true
+        item.choices.forEach((choice) => {
+          if (choice.user_answer !== Boolean(choice.is_answer)) {
+            isCorrect = false
+          }
+        })
+        if (isCorrect) {
+          item.is_correct = true
+          correctCount++
+        }
+      })
+      this.score = (correctCount / this.quiz.length) * 100
+      this.postQuizScore()
+      this.isAfterScoring = true
+      this.loaded = true
+    },
+    pickUpColor(item) {
+      const correctColor = 'pink lighten-5'
+      const incorrectColor = 'blue lighten-5'
+      if (this.isAfterScoring) {
+        return item.is_correct ? correctColor : incorrectColor
+      }
+    },
+    postQuizScore() {
+      this.sendingScore = true
+      const status = this.statuses.find(
+        (v) => v.material_id === this.quiz[0].material_id
+      )
+      const payload = {
+        material_id: this.quiz[0].material_id,
+        quiz_score: this.score,
+        is_complete: true,
+      }
+      //  リソースが存在する場合は更新，そうでない場合は作成
+      if (status) {
+        UserService.updateStatus(status.id, payload)
+          .then((response) => {
+            this.sendingScore = false
+          })
+          .catch((err) => {
+            return getError(err)
+          })
+      } else {
+        UserService.createStatus(payload)
+          .then((response) => {
+            this.sendingScore = false
+          })
+          .catch((err) => {
+            return getError(err)
+          })
+      }
+    },
+  },
+}
+</script>
+
+<style>
+/* disable時，選択肢がグレーにならないようにする */
+.v-label {
+  color: black !important;
+}
+</style>

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -13,4 +13,13 @@ export default {
   getMaterial(categoryId) {
     return API.apiClient.get('/material/' + categoryId)
   },
+  getQuiz(materialId) {
+    return API.apiClient.get('/quiz/' + materialId)
+  },
+  updateStatus(materialId, payload) {
+    return API.apiClient.post('/status/' + materialId, payload)
+  },
+  createStatus(payload) {
+    return API.apiClient.post('/status/', payload)
+  },
 }


### PR DESCRIPTION
## 作業内容
- スコアの更新に必要なAPIエンドポイントの追加
- 採点機能の実装
- UIの作成
## 期待する動作
教材ページからクイズページに遷移することができる
![image](https://user-images.githubusercontent.com/47177922/118462264-73473f00-b739-11eb-9fb3-a499ca762ddb.png)
採点をクリックすると，解説，正解，スコアが表示されスコアがアップデートされる
![image](https://user-images.githubusercontent.com/47177922/118462330-8528e200-b739-11eb-8218-4a8ae5f1a847.png)
戻るボタンをクリックすると教材ページに戻り，クイズのスコアが反映されている
![image](https://user-images.githubusercontent.com/47177922/118462617-d6d16c80-b739-11eb-9a87-86b627ad890f.png)
